### PR TITLE
Allowing spaces in code

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -65,6 +65,6 @@ class AuthComponent extends CakeAuthComponent
      */
     public function verifyCode($secret, $code)
     {
-        return $this->tfa->verifyCode($secret, $code);
+        return $this->tfa->verifyCode($secret, str_replace(' ', '', $code));
     }
 }


### PR DESCRIPTION
When using the Google Authenticator app, the 6 digits get separated in 2 parts of 3 digits. When entered exactly like this, the code isn't validated because of the space.