### PR TITLE
Change CakePHP version requirement to >=3.4.* & <4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "cakephp/cakephp": "3.4.*",
+        "cakephp/cakephp": "^3.4.*",
         "robthree/twofactorauth": "^1.4"
     },
     "require-dev": {


### PR DESCRIPTION
CakePHP is currently on 3.5.*. The current composer.json cakephp version requirement does not allow this version.

I don't believe we will see breaking changes until >=4.0 so we should allow versions >=3.4.* and <4.0