### PR TITLE
 Add a check for enabled/disabled 2FA for user

### DIFF
--- a/src/Authenticator/TwoFactorFormAuthenticator.php
+++ b/src/Authenticator/TwoFactorFormAuthenticator.php
@@ -54,6 +54,7 @@ class TwoFactorFormAuthenticator extends CakeFormAuthenticator
         ],
         'codeField' => 'code',
         'secretProperty' => 'secret',
+		'isEnabled2faProperty' => 'secret',
         'issuer' => null,
         'digits' => 6,
         'period' => 30,
@@ -120,8 +121,8 @@ class TwoFactorFormAuthenticator extends CakeFormAuthenticator
     {
         $result = parent::authenticate($request);
 
-        if (!$result->isValid() || !$this->_getUserSecret($result->getData())) {
-            // Invalid user or 2FA secret not set
+        if (!$result->isValid() || !$this->_getUser2faEnabledStatus($result->getData()) || !$this->_getUserSecret($result->getData())) {
+            // The user is invalid or the 2FA secret is not enabled/present
             return $result;
         }
 
@@ -199,7 +200,12 @@ class TwoFactorFormAuthenticator extends CakeFormAuthenticator
     {
         return Hash::get($user, $this->getConfig('secretProperty'));
     }
-
+	
+	protected function _getUser2faEnabledStatus($user)
+	{
+		return Hash::get($user, $this->getConfig('isEnabled2faProperty'));
+	}
+	
     /**
      * Get RobThree\Auth\TwoFactorAuth object
      *


### PR DESCRIPTION
Added an option for checking if the user has enabled 2FA, without explicitly removing its 2FA secret.
Up until now, the authentication check was skipped if no secret was present, but that leaves the edge case where a user might temporarily disable his 2FA, and latter enable it back while keeping the original secret.

The check is implemented in a backwards compatible manner, where if the property  `isEnabled2faProperty` is not explicitly set on `TwoFactorForm` Authenticator (inside the `Application.php`), then the behavior would be the same and check only the existence of the secret key.